### PR TITLE
Enable Tailwind CSS @apply in Svelte components in

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,6 +1,15 @@
 const path = require('path');
 
 module.exports = ({ config, mode }) => {
+    const svelteLoader = config.module.rules.find(
+        r => r.loader && r.loader.includes('svelte-loader'),
+    );
+    svelteLoader.options = {
+        ...svelteLoader.options,
+        emitCss: true,
+        hotReload: false,
+    };
+
     config.module.rules.push(
         {
             test: /\.css$/,


### PR DESCRIPTION
Storybook stories. This override to svelte-loader gets @apply working in svelte components within style tags.