### PR TITLE
Update package json to resolve error

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "rollup-plugin-livereload": "^1.0.0",
         "rollup-plugin-node-resolve": "^5.2.0",
         "rollup-plugin-postcss": "^2.0.3",
-        "rollup-plugin-svelte": "^5.0.3",
+        "rollup-plugin-svelte": "^v6.1.1",
         "rollup-plugin-terser": "^5.1.2",
         "svelte": "^3.12.1",
         "svelte-loader": "^2.13.6",


### PR DESCRIPTION
Error - Package subpath './compiler.js' is not defined by "exports"
fixed by updating rollup-plugin-svelte version
https://stackoverflow.com/a/66969405/15187131