### PR TITLE
Fix storybook command

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,10 +8,19 @@ module.exports = {
         '@storybook/addon-essentials',
         '@storybook/addon-svelte-csf',
         '@storybook/addon-storysource',
-        '@storybook/addon-a11y'
+        '@storybook/addon-a11y',
+        {
+            name: '@storybook/addon-postcss',
+            options: {
+                postcssLoaderOptions: {
+                    implementation: require('postcss'),
+                },
+            },
+        },
+
     ],
     framework: '@storybook/svelte',
     svelteOptions: {
-        preprocess: require('svelte-preprocess')({postcss: true})
+        preprocess: require('svelte-preprocess')({ postcss: true })
     }
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@storybook/addon-actions": "^6.4.13",
         "@storybook/addon-essentials": "^6.4.13",
         "@storybook/addon-links": "^6.4.13",
+        "@storybook/addon-postcss": "^2.0.0",
         "@storybook/addon-storysource": "^6.4.13",
         "@storybook/addon-svelte-csf": "^1.1.0",
         "@storybook/svelte": "^6.4.13",


### PR DESCRIPTION
By adding @storybook/addon-postcss:

```
(node:55704) DeprecationWarning: Relying on the implicit PostCSS loader is deprecated and will be removed in Storybook 7.0.
If you need PostCSS, include '@storybook/addon-postcss' in your '.storybook/main.js' file.
```

If you see "Cannot GET /", try re-running `storybook` with `--no-manager-cache`: https://issuehunt.io/r/storybookjs/storybook/issues/14672